### PR TITLE
 『支援総額が多いプロジェクト』欄の実装

### DIFF
--- a/app/controllers/toppage_controller.rb
+++ b/app/controllers/toppage_controller.rb
@@ -10,6 +10,10 @@ class ToppageController < ApplicationController
     view_history = cookie_find_or_create("project_view_history")
     @recent_viewed_projects = Project.where(id: view_history)
                                      .order(['field(id, ?)', view_history])
+
+    @projects_large_amount = @projects.sort_by{ |project| project.total_support }
+                                      .reverse
+                                      .first(4)
   end
 
   def socialgood

--- a/app/views/toppage/index.html.haml
+++ b/app/views/toppage/index.html.haml
@@ -98,7 +98,7 @@
             = render partial: 'toppage/partial/PcTopProjectList',
                      locals: { title: "支援総額が多いプロジェクト",
                                link_path: '#',
-                               projects: @projects }
+                               projects: @projects_large_amount }
 
           -# 現在募集中のプロジェクト
           .Grid.public


### PR DESCRIPTION
## WHAT
『支援総額が多いプロジェクト』欄に、全プロジェクトから`total_support`カラム降順に４つ表示するよう修正。