### PR TITLE
残りの資金調達日数表示の改善

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -19,8 +19,8 @@ class Project < ApplicationRecord
     end
   end
 
-  def left_date
-    Time.zone.at(self.limit_date - Time.current).strftime("%-d日")
+  def remaining_funding_days
+    ( self.limit_date.to_date - Time.current.to_date ).to_i
   end
 
   def achievement_rate

--- a/app/views/layouts/_Entry-type1.html.haml
+++ b/app/views/layouts/_Entry-type1.html.haml
@@ -31,7 +31,7 @@
           %dt.Entry__condition-remain-dt
             残り
           %dd.Entry__condition-remain-dd
-            #{ project.limit_date_to_month_day }
+            #{ project.remaining_funding_days } 日
 
       .Entry__gauge.Gauge.is-top
         .Gauge__obj.is-1{ style: "width: #{ project.achievement_rate }%;" }

--- a/app/views/layouts/_Entry-type2.html.haml
+++ b/app/views/layouts/_Entry-type2.html.haml
@@ -17,7 +17,6 @@
               %dd 1,553,000 円
             %dl
               %dt 残り
-              %dd
-                = project.left_date
+              %dd #{ project.remaining_funding_days } 日
           .project-type-badge.normal
             = project.project_type


### PR DESCRIPTION
## WHAT
+ 残り日数を出力するメソッドの出力を `XX日` から `XX` （日数の数字のみ）に変更した。
+ 上記に伴って影響のあるビューを修正した。

## WHY
+ 残り日数を条件とするロジックに使おうとしたとき、当初の出力が使いにくかったため。