### PR TITLE
Project_typeの日本語表示対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,3 +96,7 @@ gem 'devise'
 gem 'jquery-rails'
 # Use slick-slider
 gem "jquery-slick-rails"
+
+# rails_addon
+# enumを日本語にする
+gem 'enum_help'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erb2haml (0.1.5)
       html2haml
     erubi (1.7.1)
@@ -352,6 +354,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  enum_help
   erb2haml
   factory_bot_rails
   faker

--- a/app/views/layouts/_Entry-type1.html.haml
+++ b/app/views/layouts/_Entry-type1.html.haml
@@ -11,7 +11,7 @@
         = project.title
       .Entry__project-type-badge
         .project-type-badge.normal
-          = project.project_type
+          = project.project_type_i18n
       .Entry__info-founder.hidden-while-processing
         %span.Entry__info-founder-icon
           = image_tag(project.user.avatar.url, class:  'Entry__icon-img',

--- a/app/views/layouts/_Entry-type2.html.haml
+++ b/app/views/layouts/_Entry-type2.html.haml
@@ -23,4 +23,4 @@
                 - else
                   #{ project.remaining_time[:hour] } 時間
           .project-type-badge.normal
-            = project.project_type
+            = project.project_type_i18n

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,6 @@ module Readyfor29
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
     config.time_zone = 'Tokyo'
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,6 @@
+ja:
+  enums:
+    project:
+      project_type:
+        purchase: "購入型"
+        contribution: "寄付型"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,3 +4,27 @@ ja:
       project_type:
         purchase: "購入型"
         contribution: "寄付型"
+  date:
+    formats:
+      default: "%Y/%m/%d"
+      short: "%m/%d"
+      long: "%Y年%m月%d日(%a)"
+
+    day_names: [日曜日, 月曜日, 火曜日, 水曜日, 木曜日, 金曜日, 土曜日]
+    abbr_day_names: [日, 月, 火, 水, 木, 金, 土]
+
+    month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+    abbr_month_names: [~, 1月, 2月, 3月, 4月, 5月, 6月, 7月, 8月, 9月, 10月, 11月, 12月]
+
+    order:
+      - :year
+      - :month
+      - :day
+
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      short: "%y/%m/%d %H:%M"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %Z"
+    am: "午前"
+    pm: "午後"


### PR DESCRIPTION
## WHAT
gem `enum_help` を使用したproject_typeの日本語機能の実装とビューの修正

## WHY
project_typeのenum化により、デフォルトでは英語でしか表示できなくなっていたため。