### PR TITLE
プロジェクトのタイトル名が長すぎる場合レイアウト崩れる問題の修正

### DIFF
--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -19,7 +19,7 @@
           %label タイトル
           .project-title
             = f.text_field :title, required: true, autofocus: true,
-              placeholder: "タイトルを入力してください。"
+              placeholder: "タイトルを入力してください。(30文字以内)", maxlength: 30
           %hr
           %label 画像
           #project-image

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -19,7 +19,7 @@
           %label タイトル
           .project-title
             = f.text_field :title, required: true, autofocus: true,
-              placeholder: "タイトルを入力してください。"
+              placeholder: "タイトルを入力してください。(30文字以内)", maxlength: 30
           %hr
           %label 画像
           #project-image


### PR DESCRIPTION
## What
プロジェクト登録・更新時のタイトル入力フォームに入力文字制限を設定

## Why
プロジェクトのタイトル名が長すぎる場合レイアウト崩れてしまうため。

・タイトル入力フォームに30文字以内で入力するようmaxlengthを設定