### PR TITLE
ajaxが２回行われる問題の修正

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,8 +11,8 @@
 // about supported directives.
 //
 //= require jquery
-//= require jquery_ujs
 //= require jquery.slick
+//= require rails-ujs
 //= require activestorage
 //= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,6 @@
 //= require jquery
 //= require jquery_ujs
 //= require jquery.slick
-//= require rails-ujs
 //= require activestorage
 //= require turbolinks
 //= require_tree .


### PR DESCRIPTION
## 原因
`jquery_ujs`と`rails-ujs`は双方ともrailsのajax処理を担うライブラリで、両方とも入っていたために２回行われていた。

## 対応
`jquery_ujs`を削除。

## 参考
https://qiita.com/Thort/items/a49ccba2d02335aaa35d