### PR TITLE
[Fix] slick-sliderをロード完了時に表示するよう修正

### DIFF
--- a/app/assets/stylesheets/toppage/component/slick-slider.scss
+++ b/app/assets/stylesheets/toppage/component/slick-slider.scss
@@ -1,4 +1,9 @@
 .slick-slider {
+  display: none;
+}
+
+.slick-slider.slick-initialized {
+  display: block;
   margin-bottom: 30px;
 }
 

--- a/app/assets/stylesheets/toppage/project/PcTopCategoryProjectArea.scss
+++ b/app/assets/stylesheets/toppage/project/PcTopCategoryProjectArea.scss
@@ -75,11 +75,6 @@
   font-size: 16px;
 }
 
-.PcTopCategoryProjectArea__static-banner__2BBlL {
-  display: flex;
-  justify-content: space-between;
-}
-
 .PcTopCategoryProjectArea__announcements__1cB4R {
   display: inline-flex;
   margin-bottom: 30px;


### PR DESCRIPTION
Slick-slider（トップページのバナーが横に移動してるやつ）が、JS読み込み完了までの一瞬崩れる問題の修正。

読み込み完了時に付与されるクラスがある場合のみ、表示されるようにCSSを修正した。
ローカルだと読み込みがすぐ終わるので確認できないかも…

参考 https://www.granfairs.com/blog/staff/slick-solve-tandem