### PR TITLE
Project,return編集の画像の更新

### DIFF
--- a/app/assets/javascripts/projects/new-image.js
+++ b/app/assets/javascripts/projects/new-image.js
@@ -1,9 +1,11 @@
 $(document).on('turbolinks:load', function () {
   $('#project-image').change(function () {
-    var file = this.querySelector('input[type=file]').files[0];
+    $('#project-img-default').remove();
+    console.log(this)
+    var file = $(this).prop('files')[0];
     var reader = new FileReader();
     reader.onload = function () {
-      var img_src = $('#project-img-show').attr('src', reader.result);
+      var img_src = $('<img>').attr('src', reader.result);
       $('#project-img-show').html(img_src);
     }
     reader.readAsDataURL(file);

--- a/app/assets/javascripts/projects/new-image.js
+++ b/app/assets/javascripts/projects/new-image.js
@@ -1,7 +1,6 @@
 $(document).on('turbolinks:load', function () {
   $('#project-image').change(function () {
     $('#project-img-default').remove();
-    console.log(this)
     var file = $(this).prop('files')[0];
     var reader = new FileReader();
     reader.onload = function () {

--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -94,7 +94,7 @@
                 = r.date_select :arrival_date, dafault: Time.current,
                   use_month_numbers: true, discard_day: true
             .return-create__image-show.clearfix
-              .content 画
+              .content 画像
               .content-form
                 = r.file_field :returnimage, id: "create-return-image"
                 #return-image-show

--- a/app/views/projects/edit.html.haml
+++ b/app/views/projects/edit.html.haml
@@ -22,8 +22,11 @@
               placeholder: "タイトルを入力してください。(30文字以内)", maxlength: 30
           %hr
           %label 画像
-          #project-image
-            = f.file_field :projectimage, required: true
+          .project-image
+            = f.file_field :projectimage, id: "project-image"
+          #project-img-default
+            = image_tag "#{f.object.projectimage}"
+          #project-img-show
           %hr
           %label 募集期間
           .project-period
@@ -91,12 +94,11 @@
                 = r.date_select :arrival_date, dafault: Time.current,
                   use_month_numbers: true, discard_day: true
             .return-create__image-show.clearfix
-              .content 画像
+              .content 画
               .content-form
-                = r.file_field :returnimage, id: "create-return-image",
-                  required: true
+                = r.file_field :returnimage, id: "create-return-image"
                 #return-image-show
-                  %img{ src:"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTvOUSpHlYa1jpsFW2BZB9_T5X68Q-YwCA4GtihyEUOW7AiAqru" ,alt: "画像がありません" ,id: "return-image-default" }
+                  = image_tag "#{r.object.returnimage}"
         .return-new-link
           .btn.btn-primary.return-add-button
             = link_to "リターンを追加",


### PR DESCRIPTION
## What
プロジェクト編集画面の変更
required: trueの削除
①required: trueの削除
②現在登録している画像の表示

## Why
毎回写真を新しく登録しないと更新できなかったため

【確認方法】
project/:id/edit画面で画像を新規でセットせずに更新できるか
現在project,returnに保存されている画像が表示されているか