### PR TITLE
リターン購入完了画面のプロジェクトに戻るボタンのリンク修正

### DIFF
--- a/app/views/returns/done.html.haml
+++ b/app/views/returns/done.html.haml
@@ -14,7 +14,7 @@
         = link_to "こちら", root_path
         をご覧ください。
       .progress-button
-        = link_to project_path(1) do
+        = link_to project_path(params[:project_id]) do
           .progress-button__return
             = image_tag 'left_arrow.png'
             %p プロジェクトページに戻る


### PR DESCRIPTION
## WHAT
リターン購入完了画面のプロジェクトに戻るボタンのリンクがprojects/1になっているのをprojects/params[:project_id]に修正しました。

## WHY
プロジェクトに戻るボタンを押した時、project/1にしか移動できないため。