### PR TITLE
ユーザーのリターンの一覧表示

### DIFF
--- a/app/assets/stylesheets/users/mypage.scss
+++ b/app/assets/stylesheets/users/mypage.scss
@@ -104,6 +104,10 @@
             color: blue;
           }
         }
+        .time {
+            text-align: left;
+            padding-left: 10px;
+          }
       }
     }
     button {

--- a/app/assets/stylesheets/users/mypage.scss
+++ b/app/assets/stylesheets/users/mypage.scss
@@ -73,15 +73,38 @@
       margin: 0;
       color: gray;
     }
-    .return-list {
-      background-color: #fafafa;
+    .return-lists {
+      background-color: whitesmoke;
       box-shadow: inset 0 0 10px rgba(0,0,0,0.05);
-      width: 740px;
-      height: 83px;
       text-align: center;
       line-height: 83px;
       font-size: 15px;
       border-radius: 10px;
+      padding: 20px 0;
+      table {
+        width: 700px;
+        margin: 0 auto;
+        tr {
+          height: 30px;
+        }
+        th, td {
+          border: solid 1px black;
+          border-collapse: collapse;
+          line-height: 20px;
+        }
+        th {
+          background-color: #f0f8ff;
+          font-weight: bold;
+          text-align: center;
+        }
+        td {
+          background-color: white;
+          a {
+            display: block;
+            color: blue;
+          }
+        }
+      }
     }
     button {
       width: 578px;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,7 @@ class UsersController < ApplicationController
   end
 
   def show
+    @returns = current_user.returns.order('created_at DESC')
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @returns = current_user.returns.order('created_at DESC')
+    @returns = current_user.user_returns.order('created_at DESC')
   end
 
   def edit

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   validates :nickname, presence: true, length: { maximum: 10 }
 
   has_many :projects, dependent: :destroy
+  has_many :user_returns
   has_many :returns, through: :user_returns
   mount_uploader :avatar, AvatarUploader
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   validates :nickname, presence: true, length: { maximum: 10 }
 
   has_many :projects, dependent: :destroy
-  has_many :user_returns
+  has_many :user_returns, dependent: :destroy
   has_many :returns, through: :user_returns
   mount_uploader :avatar, AvatarUploader
 end

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -126,7 +126,7 @@
               content.id, "?select_id=#{content.id}") do
                 %button.project-select-button  このリターンを購入する
       - else
-        = render partial: 'shared/return-list', locals: {return: @returns }
+        = render partial: 'shared/return-list', locals: { return: @returns }
     .clear
     .show-projects
       .clear

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -126,36 +126,7 @@
                content.id, "?select_id=#{content.id}") do
                 %button.project-select-button  このリターンを購入する
       - else
-        - @returns.each do |content|
-          .project-return
-            .project-return__title
-              %h3= content.title
-            .project-return__price
-              %i.fa.fa-jpy
-              %strong= number_with_delimiter(content.price)
-              %span 円のリターン
-            .project-return__image
-              = image_tag( "#{content.returnimage}" )
-            .project-return__content
-              %p= simple_format(content.content)
-            .project-return__helper
-              %span.fa-stack.fa-lg
-                %i.fa.fa-circle-o.fa-stack-2x
-                %i.fa.fa-user.fa-stack-1x
-              %span ０人が支援中/
-              - if content.stock === 0
-                %span 在庫制限なし
-              - else
-                %span 残り#{ number_with_delimiter(content.price) }個
-            .project-return__arrival
-              %span.fa-stack.fa-lg
-                %i.fa.fa-circle-o.fa-stack-2x
-                %i.fa.fa-gift.fa-stack-1x
-              %span #{ content.arrival_date.year }年#{ content.arrival_date.month }月に発送予定です。
-            .project-return__purchase
-              = link_to payment_path(params[:id], 'payment/choice',
-              content.id, "?select_id=#{content.id}") do
-                %button.project-select-button  このリターンを購入する
+        = render partial: 'shared/return-list', locals: {return: @returns }
     .clear
     .show-projects
       .clear

--- a/app/views/shared/_return-list.html.haml
+++ b/app/views/shared/_return-list.html.haml
@@ -1,0 +1,30 @@
+- returns.each do |r|
+  .project-return
+    .project-return__title
+      %h3= r.title
+    .project-return__price
+      %i.fa.fa-jpy
+      %strong= number_with_delimiter(r.price)
+      %span 円のリターン
+    .project-return__image
+      = image_tag( "#{r.returnimage}" )
+    .project-return__content
+      %p= simple_format(r.content)
+    .project-return__helper
+      %span.fa-stack.fa-lg
+        %i.fa.fa-circle-o.fa-stack-2x
+        %i.fa.fa-user.fa-stack-1x
+      %span ０人が支援中/
+      - if r.stock === 0
+        %span 在庫制限なし
+      - else
+        %span 残り#{ number_with_delimiter(r.price) }個
+    .project-return__arrival
+      %span.fa-stack.fa-lg
+        %i.fa.fa-circle-o.fa-stack-2x
+        %i.fa.fa-gift.fa-stack-1x
+      %span #{ r.arrival_date.year }年#{ r.arrival_date.month }月に発送予定です。
+    .project-return__purchase
+      = link_to payment_path(params[:id], 'payment/choice',
+      r.id, "?select_id=#{r.id}") do
+        %button.project-select-button  このリターンを購入する

--- a/app/views/shared/_return-list.html.haml
+++ b/app/views/shared/_return-list.html.haml
@@ -7,7 +7,7 @@
       %strong= number_with_delimiter(r.price)
       %span 円のリターン
     .project-return__image
-      = image_tag( "#{r.returnimage}" )
+      = image_tag("#{ r.returnimage }")
     .project-return__content
       %p= simple_format(r.content)
     .project-return__helper
@@ -26,5 +26,5 @@
       %span #{ r.arrival_date.year }年#{ r.arrival_date.month }月に発送予定です。
     .project-return__purchase
       = link_to payment_path(params[:id], 'payment/choice',
-      r.id, "?select_id=#{r.id}") do
+      r.id, "?select_id=#{ r.id }") do
         %button.project-select-button  このリターンを購入する

--- a/app/views/users/_returns.html.haml
+++ b/app/views/users/_returns.html.haml
@@ -12,5 +12,5 @@
       %td= r.user_returns.count
       %td= number_with_delimiter(r.price)
       %td= number_with_delimiter("#{ r.price * r.user_returns.count }")
-      %td= "#{r.created_at.year}年#{ r.created_at.month }月#{ r.created_at.day }日"
-      %td= "#{ r.arrival_date.year }年#{ r.arrival_date.month }月"
+      %td #{ r.created_at.year }年#{ r.created_at.month }月#{ r.created_at.day }日
+      %td #{ r.arrival_date.year }年#{ r.arrival_date.month }月

--- a/app/views/users/_returns.html.haml
+++ b/app/views/users/_returns.html.haml
@@ -12,5 +12,5 @@
       %td= r.user_returns.count
       %td= number_with_delimiter(r.price)
       %td= number_with_delimiter("#{ r.price * r.user_returns.count }")
-      %td= "#{r.created_at.year}年#{r.created_at.month}月#{r.created_at.day}日"
+      %td= "#{r.created_at.year}年#{ r.created_at.month }月#{ r.created_at.day }日"
       %td= "#{ r.arrival_date.year }年#{ r.arrival_date.month }月"

--- a/app/views/users/_returns.html.haml
+++ b/app/views/users/_returns.html.haml
@@ -4,13 +4,13 @@
     %th 個数
     %th 価格
     %th 合計金額
-    %th 購入日
+    %th 購入日時
     %th 到着日
   - returns.each do |r|
     %tr
-      %td= link_to  "#{ r.project.title }", project_path(id: r.project)
-      %td= r.user_returns.count
-      %td= number_with_delimiter(r.price)
-      %td= number_with_delimiter("#{ r.price * r.user_returns.count }")
-      %td #{ r.created_at.year }年#{ r.created_at.month }月#{ r.created_at.day }日
-      %td #{ r.arrival_date.year }年#{ r.arrival_date.month }月
+      %td= link_to  "#{ r.return.project.title }", project_path(id: r.return.project)
+      %td= r.count
+      %td= number_with_delimiter(r.return.price)
+      %td= number_with_delimiter("#{ r.return.price * r.count }")
+      %td.time #{ r.created_at.year }年#{ r.created_at.month }月#{ r.created_at.day }日#{ r.created_at.hour}時#{ r.created_at.min}分
+      %td #{ r.return.arrival_date.year }年#{ r.return.arrival_date.month }月

--- a/app/views/users/_returns.html.haml
+++ b/app/views/users/_returns.html.haml
@@ -8,7 +8,8 @@
     %th 到着日
   - returns.each do |r|
     %tr
-      %td= link_to  "#{ r.return.project.title }", project_path(id: r.return.project)
+      %td= link_to  "#{ r.return.project.title }",
+        project_path(id: r.return.project)
       %td= r.count
       %td= number_with_delimiter(r.return.price)
       %td= number_with_delimiter("#{ r.return.price * r.count }")

--- a/app/views/users/_returns.html.haml
+++ b/app/views/users/_returns.html.haml
@@ -1,0 +1,16 @@
+%table
+  %tr
+    %th プロジェクト名(リンク)
+    %th 個数
+    %th 価格
+    %th 合計金額
+    %th 購入日
+    %th 到着日
+  - returns.each do |r|
+    %tr
+      %td= link_to  "#{ r.project.title }", project_path(id: r.project)
+      %td= r.user_returns.count
+      %td= number_with_delimiter(r.price)
+      %td= number_with_delimiter("#{ r.price * r.user_returns.count }")
+      %td= "#{r.created_at.year}年#{r.created_at.month}月#{r.created_at.day}日"
+      %td= "#{ r.arrival_date.year }年#{ r.arrival_date.month }月"

--- a/app/views/users/_returns.html.haml
+++ b/app/views/users/_returns.html.haml
@@ -13,5 +13,5 @@
       %td= r.count
       %td= number_with_delimiter(r.return.price)
       %td= number_with_delimiter("#{ r.return.price * r.count }")
-      %td.time #{ r.created_at.year }年#{ r.created_at.month }月#{ r.created_at.day }日#{ r.created_at.hour}時#{ r.created_at.min}分
+      %td.time #{r.created_at.strftime('%Y年%m月%d日 %H時%M分')}
       %td #{ r.return.arrival_date.year }年#{ r.return.arrival_date.month }月

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -26,5 +26,8 @@
   .mypage-right
     .right-wrapper
       %h2 購入履歴
-      .return-list 表示できる履歴がありません
-      %button.return-more もっと見る
+      .return-lists
+        - if @returns.present?
+          = render partial: 'users/returns', locals: {returns: @returns}
+        - else
+          .return-list 表示できる履歴がありません


### PR DESCRIPTION
## What
ユーザーの購入したリターンを表示する機能を実装

## Why
ユーザーがリターン購入後に、購入したリターンを確認するため

【確認方法】
①ユーザーでログイン
②(1)リターンを購入しないでユーザーの購入履歴(users/:id)のページを確認し、if文が機能しているか
②(2)リターンを購入→users/:idのページで購入したリターンが一覧で表示されているか

【意見をもらいたいところ】
①一覧のテーブルに表示する内容で追加したいものがあれば教えてください
②できれば購入したリターンを削除する機能も別途で作成し、テーブルに加えたいと思ってますがいかがでしょうか