### PR TITLE
プロジェクトshowのDB集計表示

### DIFF
--- a/app/assets/stylesheets/projects/show-info.scss
+++ b/app/assets/stylesheets/projects/show-info.scss
@@ -20,7 +20,6 @@
       border-radius: 10px;
     }
     .progress-level-of-achievement{
-      width: 80%;
       p{
         text-align: left;
         margin-left: 10px;

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -20,6 +20,14 @@ class ProjectsController < ApplicationController
     cookie_save("project_view_history", view_history)
     @returns = @project.returns.order('price ASC' )
     @tags = @project.tags
+
+    # 各リターンに支援した一番多いユーザー人数をプロジェクト支援者数とする。
+    @total_user_max = 0
+    @returns.each do |return_item|
+      if @total_user_max < return_item.total_user
+        @total_user_max = return_item.total_user
+      end
+    end
   end
 
   def new

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -20,14 +20,7 @@ class ProjectsController < ApplicationController
     cookie_save("project_view_history", view_history)
     @returns = @project.returns.order('price ASC' )
     @tags = @project.tags
-
-    # 各リターンに支援した一番多いユーザー人数をプロジェクト支援者数とする。
-    @total_user_max = 0
-    @returns.each do |return_item|
-      if @total_user_max < return_item.total_user
-        @total_user_max = return_item.total_user
-      end
-    end
+    @total_user_max = @project.total_user_max(@returns)
   end
 
   def new

--- a/app/controllers/user_returns_controller.rb
+++ b/app/controllers/user_returns_controller.rb
@@ -3,11 +3,11 @@ class UserReturnsController < ApplicationController
     @return = Return.find(params[:return_id])
     @project = @return.project
 
-    # リターン購入分のレコード保存とプロジェクトのtotal_supportに購入金額分を加算する
-    if UserReturn.import UserReturn.user_return_array(user_return_params[:number], user_return_params[:user_id])
-      if @project.update(total_support: @project.total_support += Project.return_sum(user_return_params[:number]))
-        if Return.total_user_sum(user_return_params[:number], current_user.id)
-          render 'returns/done'
+    # 初めてリターン購入した人ならばtotal_userに1足す、リターン購入分のレコード保存、プロジェクトのtotal_supportに購入金額分を加算
+    if Return.total_user_sum(user_return_params[:number], current_user.id)
+      if UserReturn.import UserReturn.user_return_array(user_return_params[:number], user_return_params[:user_id])
+        if @project.update(total_support: @project.total_support += Project.return_sum(user_return_params[:number]))
+            render 'returns/done'
         end
       end
     end

--- a/app/controllers/user_returns_controller.rb
+++ b/app/controllers/user_returns_controller.rb
@@ -6,7 +6,9 @@ class UserReturnsController < ApplicationController
     # リターン購入分のレコード保存とプロジェクトのtotal_supportに購入金額分を加算する
     if UserReturn.import UserReturn.user_return_array(user_return_params[:number], user_return_params[:user_id])
       if @project.update(total_support: @project.total_support += Project.return_sum(user_return_params[:number]))
-        render 'returns/done'
+        if Return.total_user_sum(user_return_params[:number], current_user.id)
+          render 'returns/done'
+        end
       end
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -53,7 +53,8 @@ class Project < ApplicationRecord
     return sum
   end
 
-  # 各リターンに支援した一番多いユーザー人数を返却する。
+  # 対象プロジェクトの各リターンの中で支援者数が一番多い人数を返却
+  # returns : 対象プロジェクトのリターンオブジェクト
   def total_user_max(returns)
     total_user_max = 0
     returns.each do |return_item|

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -53,4 +53,15 @@ class Project < ApplicationRecord
     return sum
   end
 
+  # 各リターンに支援した一番多いユーザー人数を返却する。
+  def total_user_max(returns)
+    total_user_max = 0
+    returns.each do |return_item|
+      if total_user_max < return_item.total_user
+        total_user_max = return_item.total_user
+      end
+    end
+    return total_user_max
+  end
+
 end

--- a/app/models/return.rb
+++ b/app/models/return.rb
@@ -3,4 +3,17 @@ class Return < ApplicationRecord
   has_many :user_returns, dependent: :destroy
   has_many :users, through: :user_returns
   mount_uploader :returnimage, ReturnImageUploader
+
+  def self.total_user_sum(params_number, current_user_id)
+    params_number.each do |key, value|
+      unless value.to_i == 0
+        return_item = Return.find(key)
+        user_returns = UserReturn.where("(return_id = ?) AND (user_id = ?)", return_item.id, current_user_id)
+        return_item.update(total_user: return_item.total_user += 1) unless user_returns.count == 0
+
+        return true;
+      end
+    end
+    return false;
+  end
 end

--- a/app/models/return.rb
+++ b/app/models/return.rb
@@ -4,6 +4,7 @@ class Return < ApplicationRecord
   has_many :users, through: :user_returns
   mount_uploader :returnimage, ReturnImageUploader
 
+  # まだ購入したリターン出ない場合、total_userに加算する
   def self.total_user_sum(params_number, current_user_id)
     params_number.each do |key, value|
       unless value.to_i == 0

--- a/app/models/return.rb
+++ b/app/models/return.rb
@@ -5,6 +5,8 @@ class Return < ApplicationRecord
   mount_uploader :returnimage, ReturnImageUploader
 
   # 初めて購入したリターンの場合、total_userに加算する
+  # params_number(hash配列) : key(return_id):value(count)
+  # current_user_id(int)) : 現在ログインしているuser_id
   def self.total_user_sum(params_number, current_user_id)
     params_number.each do |key, value|
       unless value.to_i == 0

--- a/app/models/return.rb
+++ b/app/models/return.rb
@@ -4,17 +4,14 @@ class Return < ApplicationRecord
   has_many :users, through: :user_returns
   mount_uploader :returnimage, ReturnImageUploader
 
-  # まだ購入したリターン出ない場合、total_userに加算する
+  # 初めて購入したリターンの場合、total_userに加算する
   def self.total_user_sum(params_number, current_user_id)
     params_number.each do |key, value|
       unless value.to_i == 0
         return_item = Return.find(key)
         user_returns = UserReturn.where("(return_id = ?) AND (user_id = ?)", return_item.id, current_user_id)
-        return_item.update(total_user: return_item.total_user += 1) unless user_returns.count == 0
-
-        return true;
+        return return_item.update(total_user: return_item.total_user += 1) if user_returns.count == 0
       end
     end
-    return false;
   end
 end

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -47,7 +47,7 @@
               %span 円
         .project-info__text
           %span.span-project.span-project__title 支援者数
-          %span.span-project.span-project__data 90人
+          %span.span-project.span-project__data= "#{@total_user_max}人"
         .project-info__text
           %span.span-project.span-project__title 残り日数
           %span.span-project.span-project__data

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -59,8 +59,8 @@
               #{ @project.remaining_time[:sec] } 秒
         .project-info__progress
           .progress
-            .progress-bar.progress-bar-danger.progress-level-of-achievement
-              %p 80%
+            .progress-bar.progress-bar-danger.progress-level-of-achievement{style: "width: #{ @project.achievement_rate }%;"}
+              %p= "#{ @project.achievement_rate } %"
         = link_to payment_path(params[:id], 'payment/choice',
                1, ''), class: 'btn-link' do
           .btn-link__button.btn.btn-danger
@@ -71,7 +71,6 @@
           %span.btn.btn-primary プロジェクトを編集する
         = link_to project_path, method: :delete do
           %span.btn.btn-primary.delete-btn プロジェクトを削除する
-        %p このプロジェクトはAll or nothing形式です。7月31日（火）午後11:00までに、2,450,000円以上集まった場合に成立となります。
   .bottom-content
     .bottom-content__tab-btm
       .project-tabs.select

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -27,7 +27,7 @@
             %p= @project.user.nickname
         .project-info__big-text
           %span.span-project.span-project__title-big 支援総額
-          %span.span-project.span-project__data-big 1,000,000円
+          %span.span-project.span-project__data-big= "#{@project.total_support}円"
         - if @project.next_goal.nil?
           .project-info__text
             %span.span-project.span-project__title 目標金額

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -27,7 +27,7 @@
             %p= @project.user.nickname
         .project-info__big-text
           %span.span-project.span-project__title-big 支援総額
-          %span.span-project.span-project__data-big= "#{@project.total_support}円"
+          %span.span-project.span-project__data-big= "#{number_with_delimiter(@project.total_support)}円"
         - if @project.next_goal.nil?
           .project-info__text
             %span.span-project.span-project__title 目標金額

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -24,7 +24,9 @@
             %p= @project.user.nickname
         .project-info__big-text
           %span.span-project.span-project__title-big 支援総額
-          %span.span-project.span-project__data-big= "#{number_with_delimiter(@project.total_support)}円"
+          %span.span-project.span-project__data-big
+            = number_with_delimiter(@project.total_support)
+            円
         - if @project.next_goal.nil?
           .project-info__text
             %span.span-project.span-project__title 目標金額
@@ -44,7 +46,9 @@
               %span 円
         .project-info__text
           %span.span-project.span-project__title 支援者数
-          %span.span-project.span-project__data= "#{@total_user_max}人"
+          %span.span-project.span-project__data
+            = number_with_delimiter(@total_user_max)
+            人
         .project-info__text
           %span.span-project.span-project__title 残り日数
           %span.span-project.span-project__data
@@ -56,7 +60,7 @@
               #{ @project.remaining_time[:sec] } 秒
         .project-info__progress
           .progress
-            .progress-bar.progress-bar-danger.progress-level-of-achievement{style: "width: #{ @project.achievement_rate }%;"}
+            .progress-bar.progress-bar-danger.progress-level-of-achievement{ style: "width: #{ @project.achievement_rate }%;" }
               %p= "#{ @project.achievement_rate } %"
         = link_to payment_path(params[:id], 'payment/choice',
                "#{@returns.first.id}", ''), class: 'btn-link' do

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -4,9 +4,6 @@
       = link_to root_path do
         クラウドファンディングトップ
       %span >
-      = link_to root_path do
-        地域
-      %span >
       = @project.title
     .top-content__title
       %h1
@@ -62,7 +59,7 @@
             .progress-bar.progress-bar-danger.progress-level-of-achievement{style: "width: #{ @project.achievement_rate }%;"}
               %p= "#{ @project.achievement_rate } %"
         = link_to payment_path(params[:id], 'payment/choice',
-               1, ''), class: 'btn-link' do
+               "#{@returns.first.id}", ''), class: 'btn-link' do
           .btn-link__button.btn.btn-danger
             %p このプロジェクトを支援する
     .top-content__info-footer

--- a/db/migrate/20180726060832_add_total_user_to_returns.rb
+++ b/db/migrate/20180726060832_add_total_user_to_returns.rb
@@ -1,0 +1,5 @@
+class AddTotalUserToReturns < ActiveRecord::Migration[5.2]
+  def change
+    add_column :returns, :total_user, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_07_19_164619) do
+ActiveRecord::Schema.define(version: 2018_07_26_060832) do
 
   create_table "image_upload_tests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "image"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2018_07_19_164619) do
     t.bigint "project_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "total_user", default: 0, null: false
     t.index ["project_id"], name: "index_returns_on_project_id"
   end
 


### PR DESCRIPTION
## WHAT
プロジェクトshowのDB集計表示(支援総額・支援者数・達成率)を反映させました。

## WHY
仮文字列として表示していたため。購入処理が完成したため。

・プロジェクトshowで支援総額を表示するため、ruturnsモデルに各リターンごとの支援者数を格納するカラム(total_user)を作成しました。