### PR TITLE
ユーザーのログイン時のビューの修正、ユーザー退会時にconfirmする

### DIFF
--- a/app/assets/stylesheets/users/sign_in.scss
+++ b/app/assets/stylesheets/users/sign_in.scss
@@ -2,7 +2,8 @@
   height: 400px;
   width: 640px;
   margin: 0 auto;
-  margin-top: 80px;
+  margin-top: 50px;
+  margin-bottom: 50px;
   box-shadow: 5px 5px 20px;
   .user-left{
     width: 314px;

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -212,7 +212,7 @@
         .user-edit-main
           %p.title 退会手続きへ
           %p.information
-          = link_to "退会", "/users", method: :delete
+          = link_to "退会", "/users", data: { confirm: "退会してよろしいですか？" } , method: :delete
         .user-edit-sub
           %p.explain Readyforを退会します。
           %p.user-edit-contents

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -212,7 +212,8 @@
         .user-edit-main
           %p.title 退会手続きへ
           %p.information
-          = link_to "退会", "/users", data: { confirm: "退会してよろしいですか？" } , method: :delete
+          = link_to "退会", "/users", data: { confirm: "本当に退会しますか？" },
+            method: :delete
         .user-edit-sub
           %p.explain Readyforを退会します。
           %p.user-edit-contents


### PR DESCRIPTION
## What
①サインイン画面にmargin-bottomを設定
②ユーザー退会時confirm
## Why
①見た目が悪かったため
②退会を減らすため、誤操作を防ぐため