### PR TITLE
オレンジゲージの実装

### DIFF
--- a/app/assets/stylesheets/toppage/component/Gauge.scss
+++ b/app/assets/stylesheets/toppage/component/Gauge.scss
@@ -37,6 +37,10 @@
   border-radius: 4px 0px 0px 4px;
 }
 
+.Gauge__obj.is-0 {
+  background-color: #ee6400;
+}
+
 .Gauge__obj.is-1 {
   background-color: #DF051C;
 }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,9 +25,22 @@ class Project < ApplicationRecord
     @days_life >= 0
   end
 
+  def success?
+    self.total_support >= self.goal
+  end
+
   def achievement_rate
     return 0 if self.total_support == 0
     ((self.total_support.to_f / self.goal.to_f) * 100).floor
+  end
+
+  def achievement_rate_next_goal
+    return 0 if self.total_support == 0
+    ((self.total_support.to_f / self.next_goal.to_f) * 100).floor
+  end
+
+  def strech_rate
+    ((self.goal.to_f / self.next_goal.to_f) * 100).floor
   end
 
   def remaining_time

--- a/app/views/layouts/_Entry-type1.html.haml
+++ b/app/views/layouts/_Entry-type1.html.haml
@@ -37,6 +37,12 @@
               #{ project.remaining_time[:hour] } 時間
 
       .Entry__gauge.Gauge.is-top
-        .Gauge__obj.is-1{ style: "width: #{ project.achievement_rate }%;" }
-        .Gauge__txt
-          #{ project.achievement_rate } %
+        - if project.success? && project.next_goal
+          .Gauge__obj.is-0{ style: "width: #{ project.achievement_rate_next_goal }%;" }
+          .Gauge__obj.is-1{ style: "width: #{ project.strech_rate }%;" }
+          .Gauge__txt
+            #{ project.achievement_rate } %
+        - else
+          .Gauge__obj.is-1{ style: "width: #{ project.achievement_rate }%;" }
+          .Gauge__txt
+            #{ project.achievement_rate } %


### PR DESCRIPTION
## WHAT

fix #118 
支援金額が目標金額に対して100%を越えた場合、超過分をオレンジのゲージで表現する。

### 仕様
+ 目標金額に到達していない場合 ... 目標金額に対する進捗率を赤ゲージで表示。

+ 目標金額に到達している場合
  + 第二目標が設定されている場合 ... 第二目標を100%として、超過分をオレンジで表示。
  + 第二目標が未設定の場合 ... オレンジは表示せず、進捗率を100%以上にする。

[![Image from Gyazo](https://i.gyazo.com/6c3d1befa2c1f60c3a45c421d86f7750.png)](https://gyazo.com/6c3d1befa2c1f60c3a45c421d86f7750)

