### PR TITLE
クレジットカード・銀行振込の数字入力フォームに入力制限を設定

### DIFF
--- a/app/assets/javascripts/returns/bank-input.js
+++ b/app/assets/javascripts/returns/bank-input.js
@@ -1,19 +1,27 @@
 $(document).on('turbolinks:load', function () {
   $("#bank-input").submit(function () {
-    if ($("bank_name-form").val() == '') {
+    if ($("#bank_name-form").val() == '') {
       alert('銀行名を入力してください');
       return false;
-    } else if ($("branch_office-form").val() == '') {
+    } else if ($("#branch_office-form").val() == '') {
       alert('支店名を入力してください');
       return false;
-    } else if ($("name-form").val() == '') {
+    } else if ($("#name-form").val() == '') {
       alert('口座氏名を入力してください');
       return false;
-    } else if ($("account_number-form").val() == '') {
+    } else if ($("#account_number-form").val() == '') {
       alert('口座番号を入力してください');
+      return false;
+    } else if ($("#account_number-form").val().length < 7) {
+      alert('口座番号が7桁入力されていません');
       return false;
     } else {
       $("#bank-input").submit();
+    }
+  });
+  $('#account_number-form').on('keypress', function () {
+    if (this.value.length > 6) {
+      this.value = this.value.slice(0, 6);
     }
   });
 });

--- a/app/assets/javascripts/returns/bank-input.js
+++ b/app/assets/javascripts/returns/bank-input.js
@@ -1,15 +1,15 @@
 $(document).on('turbolinks:load', function () {
   $("#bank-input").submit(function () {
-    if ($("input[name='bank_name']").val() == '') {
+    if ($("bank_name-form").val() == '') {
       alert('銀行名を入力してください');
       return false;
-    } else if ($("input[name='branch_office']").val() == '') {
+    } else if ($("branch_office-form").val() == '') {
       alert('支店名を入力してください');
       return false;
-    } else if ($("input[name='name']").val() == '') {
+    } else if ($("name-form").val() == '') {
       alert('口座氏名を入力してください');
       return false;
-    } else if ($("input[name='account_number']").val() == '') {
+    } else if ($("account_number-form").val() == '') {
       alert('口座番号を入力してください');
       return false;
     } else {

--- a/app/assets/javascripts/returns/card-input.js
+++ b/app/assets/javascripts/returns/card-input.js
@@ -4,13 +4,13 @@ $(document).on('turbolinks:load', function () {
       alert('クレジットカード番号を入力してください');
       return false;
     } else if ($("#card-input-form").val().length < 16) {
-      alert('クレジットカード番号の16桁が入力されていません');
+      alert('クレジットカード番号が16桁入力されていません');
       return false;
     } else if ($("#cvc-input-form").val() == '') {
       alert('CVCを入力してください');
       return false;
     } else if ($("#cvc-input-form").val().length < 3) {
-      alert('CVCの3桁が入力されていません');
+      alert('CVCが3桁入力されていません');
       return false;
     } else {
       $("#card-input").submit();

--- a/app/assets/javascripts/returns/card-input.js
+++ b/app/assets/javascripts/returns/card-input.js
@@ -10,4 +10,14 @@ $(document).on('turbolinks:load', function () {
       $("#card-input").submit();
     }
   });
+  $('#card-input-form').on('keypress', function () {
+    if (this.value.length > 15) {
+      this.value = this.value.slice(0, 15);
+    }
+  });
+  $('#cvc-input-form').on('keypress', function () {
+    if (this.value.length > 2) {
+      this.value = this.value.slice(0, 2);
+    }
+  });
 });

--- a/app/assets/javascripts/returns/card-input.js
+++ b/app/assets/javascripts/returns/card-input.js
@@ -10,11 +10,13 @@ $(document).on('turbolinks:load', function () {
       $("#card-input").submit();
     }
   });
+
   $('#card-input-form').on('keypress', function () {
     if (this.value.length > 15) {
       this.value = this.value.slice(0, 15);
     }
   });
+
   $('#cvc-input-form').on('keypress', function () {
     if (this.value.length > 2) {
       this.value = this.value.slice(0, 2);

--- a/app/assets/javascripts/returns/card-input.js
+++ b/app/assets/javascripts/returns/card-input.js
@@ -3,8 +3,14 @@ $(document).on('turbolinks:load', function () {
     if ($("#card-input-form").val() == '') {
       alert('クレジットカード番号を入力してください');
       return false;
+    } else if ($("#card-input-form").val().length < 16) {
+      alert('クレジットカード番号の16桁が入力されていません');
+      return false;
     } else if ($("#cvc-input-form").val() == '') {
       alert('CVCを入力してください');
+      return false;
+    } else if ($("#cvc-input-form").val().length < 3) {
+      alert('CVCの3桁が入力されていません');
       return false;
     } else {
       $("#card-input").submit();

--- a/app/assets/javascripts/returns/card-input.js
+++ b/app/assets/javascripts/returns/card-input.js
@@ -1,9 +1,9 @@
 $(document).on('turbolinks:load', function () {
   $("#card-input").submit(function () {
-    if ($("input[name='card']").val() == '') {
+    if ($("#card-input-form").val() == '') {
       alert('クレジットカード番号を入力してください');
       return false;
-    } else if ($("input[name='cvc']").val() == '') {
+    } else if ($("#cvc-input-form").val() == '') {
       alert('CVCを入力してください');
       return false;
     } else {

--- a/app/views/returns/_bank.html.haml
+++ b/app/views/returns/_bank.html.haml
@@ -11,19 +11,23 @@
         %tr
           %th 銀行名
           %td
-            = text_field_tag :bank_name, nil, id: 'bank_name-form'
+            = text_field_tag :bank_name, nil,
+             id: 'bank_name-form'
         %tr
           %th 支店名
           %td
-            = text_field_tag :branch_office, nil, id: 'branch_office-form'
+            = text_field_tag :branch_office, nil,
+             id: 'branch_office-form'
         %tr
           %th 口座氏名
           %td
-            = text_field_tag :name, nil, id: 'name-form'
+            = text_field_tag :name, nil,
+             id: 'name-form'
         %tr
           %th 口座番号
           %td
-            = number_field_tag :account_number, nil, maxlength: 7, id: 'account_number-form'
+            = number_field_tag :account_number, nil, maxlength: 7,
+             id: 'account_number-form'
       .about-settlement-system
         %h2 決済システムについて
         %p

--- a/app/views/returns/_bank.html.haml
+++ b/app/views/returns/_bank.html.haml
@@ -11,19 +11,19 @@
         %tr
           %th 銀行名
           %td
-            = text_field_tag :bank_name
+            = text_field_tag :bank_name, nil, id: 'bank_name-form'
         %tr
           %th 支店名
           %td
-            = text_field_tag :branch_office
+            = text_field_tag :branch_office, nil, id: 'branch_office-form'
         %tr
           %th 口座氏名
           %td
-            = text_field_tag :name
+            = text_field_tag :name, nil, id: 'name-form'
         %tr
           %th 口座番号
           %td
-            = number_field_tag :account_number
+            = number_field_tag :account_number, nil, maxlength: 7, id: 'account_number-form'
       .about-settlement-system
         %h2 決済システムについて
         %p

--- a/app/views/returns/_credit-card.html.haml
+++ b/app/views/returns/_credit-card.html.haml
@@ -17,11 +17,11 @@
           %tr
             %th カード番号
             %td
-              = number_field_tag :card, id: 'card-input-form', maxlength: 16
+              = number_field_tag :card, nil, maxlength: 16, id: 'card-input-form'
           %tr
             %th CVC番号
             %td
-              = number_field_tag :cvc, id: 'cvc-input-form', maxlength: 3
+              = number_field_tag :cvc, nil, maxlength: 3, id: 'cvc-input-form'
           %tr
             %th カード有効期限
             %td

--- a/app/views/returns/_credit-card.html.haml
+++ b/app/views/returns/_credit-card.html.haml
@@ -17,11 +17,13 @@
           %tr
             %th カード番号
             %td
-              = number_field_tag :card, nil, maxlength: 16, id: 'card-input-form'
+              = number_field_tag :card, nil, maxlength: 16,
+               id: 'card-input-form'
           %tr
             %th CVC番号
             %td
-              = number_field_tag :cvc, nil, maxlength: 3, id: 'cvc-input-form'
+              = number_field_tag :cvc, nil, maxlength: 3,
+               id: 'cvc-input-form'
           %tr
             %th カード有効期限
             %td

--- a/app/views/returns/_credit-card.html.haml
+++ b/app/views/returns/_credit-card.html.haml
@@ -17,11 +17,11 @@
           %tr
             %th カード番号
             %td
-              = number_field_tag :card
+              = number_field_tag :card, id: 'card-input-form', maxlength: 16
           %tr
             %th CVC番号
             %td
-              = number_field_tag :cvc
+              = number_field_tag :cvc, id: 'cvc-input-form', maxlength: 3
           %tr
             %th カード有効期限
             %td


### PR DESCRIPTION
## What
・クレジットカード・銀行振込の数字入力フォームに入力文字数制限と指定桁数に達していない場合のエラーメッセージ追加
・jsでの入力フォームid指定方法の変更

## Why
本決済処理実装に伴った準備のため。

確認方法
・クレジットカード番号が16桁までしか入力出来ないこと。
・CVC番号が3桁までしか入力出来ないこと。
・銀行口座が7桁までしか入力出来ないこと。
・各桁数に達していない場合、次の画面に進めないこと。