### PR TITLE
test環境にenvの追加

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -5,6 +5,8 @@ development:
 
 test:
   secret_key_base: ~~~~~~~~
+  aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+  aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
## WHAT
テスト環境にてawsの環境変数を読み込むように設定。

## WHY
テスト実行時にawsのキーがないよって怒られるため。

## 確認点
`bundle exec rspec`でawsのキーを要求されないか。