### PR TITLE
ユーザーのeditページの微修正

### DIFF
--- a/app/assets/stylesheets/users/edit.scss
+++ b/app/assets/stylesheets/users/edit.scss
@@ -89,7 +89,7 @@
       .btn{
         display: block;
         background-color: green;
-        width: 120px;
+        width: 150px;
         height: 28px;
         color: white;
         margin-left: 100px;

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -63,7 +63,7 @@
               .field-input
                 = f.email_field :email, autofocus: true
               .actions
-                = f.submit "確認メールを送信", class: 'btn'
+                = f.submit "メールアドレスを変更", class: 'btn'
       .user-edit-contents
         .user-edit-main
           %p.title パスワード
@@ -114,7 +114,7 @@
               %p プロフィールを入力:
               %br
               .field-input
-                = f.text_field :profile, class: "content-form", placeholder: "プロフィールの内容を入力してください"
+                = f.text_area :profile, class: "content-form", placeholder: "プロフィールの内容を入力してください"
               .actions
                 %input.btn{ value: "更新する", type: "submit" }
       .user-edit-contents

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -114,7 +114,8 @@
               %p プロフィールを入力:
               %br
               .field-input
-                = f.text_area :profile, class: "content-form", placeholder: "プロフィールの内容を入力してください"
+                = f.text_area :profile, class: "content-form",
+                  placeholder: "プロフィールの内容を入力してください"
               .actions
                 %input.btn{ value: "更新する", type: "submit" }
       .user-edit-contents

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -5,4 +5,4 @@
     .profile-top
       = current_user.nickname
     .profile-bottom
-      = current_user.profile
+      = simple_format(current_user.profile)


### PR DESCRIPTION
##What
ユーザーのeditページの微修正

## Why
確認したところ、イケてない部分があったため

①メールアドレスの変更
ボタンの名前を修正

②プロフィール登録
入力フォームをtext_areaに変更

③users/:id/profileのprofile部分の変更
②で入力フォームを変更したことに伴い、simple_formatで改行が反映されるようにした