### PR TITLE
プロジェクト登録時にリターンの複数登録

### DIFF
--- a/app/assets/javascripts/return.js
+++ b/app/assets/javascripts/return.js
@@ -10,4 +10,7 @@ $(document).on('turbolinks:load', function(){
     }
     reader.readAsDataURL(file);
   });
+  $('.remove-new-return').on("click",function(){
+    $(this).parent().parent('.return-fields').html('');
+  })
 });

--- a/app/assets/stylesheets/projects/returns/project-new.scss
+++ b/app/assets/stylesheets/projects/returns/project-new.scss
@@ -16,15 +16,15 @@
     }
   }
   h2 {
-    margin:0px 0 10px 10px;
-    padding-top:10px;
+    margin:0px 0 15px 10px;
+    padding-top: 15px;
     font-size: 14px;
   }
   .box-size{
     width: 550px;
     height: 40px;
     background-color: blue;
-    margin:0 auto;
+    margin: 0 auto;
     border-left: 1px solid black;
     border-right: 1px solid black;
     border-bottom: 1px solid black;
@@ -76,9 +76,12 @@
       height: 280px;
     }
     .content-form {
+      height: 280px;
+      #create-return-image {
+        height: 20px;
+      }
       #return-image-show {
       font-size: 8px;
-      width: 100%;
       height: 260px;
       }
       img {

--- a/app/assets/stylesheets/projects/returns/return-new.scss
+++ b/app/assets/stylesheets/projects/returns/return-new.scss
@@ -7,8 +7,8 @@
     border-radius: 10px;
     margin: 0 auto;
     h2 {
-      margin: 0 0 10px 10px;
-      padding-top: 10px;
+      margin: 0 0 20px 10px;
+      padding-top: 20px;
       font-size: 14px;
     }
     .box-size{

--- a/app/views/projects/new.html.haml
+++ b/app/views/projects/new.html.haml
@@ -74,40 +74,80 @@
       .tab-content.hide
         .tab-content__form-group
           %h1 リターン
-        .return-create
-          = f.fields_for :returns do |r|
-            %h2 リターンの新規登録
-            .return-create__title.box-size
-              .content タイトル
-              .content-form
-                = r.text_field :title, required: true, autofocus: true,
-                  placeholder: "タイトルを入力してください。"
-            .return-create__price.box-size
-              .content
-                %span 価格
-                %i.fa.fa-jpy
-              .content-form
-                = r.number_field :price, required: true
-            .return-create__content.clearfix
-              .content 説明
-              .content-form
-                = r.text_area :content, required: true, autofocus: true,
-                  placeholder: "説明文を入力してください。"
-            .return-create__stock.box-size
-              .content 在庫数
-              .content-form
-                = r.number_field :stock, required: true,
-                  placeholder: "在庫数に制限がない場合は０としてください"
-            .return-create__arrival.box-size
-              .content 発送予定日
-              .content-form
-                = r.date_select :arrival_date, dafault: Time.current,
-                  use_month_numbers: true, discard_day: true
-            .return-create__image-show.clearfix
-              .content 画像
-              .content-form
-                = r.file_field :returnimage, id: "create-return-image",
-                  required: true
-                #return-image-show
-                  %img{ src:"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTvOUSpHlYa1jpsFW2BZB9_T5X68Q-YwCA4GtihyEUOW7AiAqru" ,alt: "画像がありません" ,id: "return-image-default" }
+          .return-create
+            = f.fields_for :returns do |r|
+              %h2 リターンの新規登録
+              .return-create__title.box-size
+                .content タイトル
+                .content-form
+                  = r.text_field :title, required: true, autofocus: true,
+                    placeholder: "タイトルを入力してください。"
+              .return-create__price.box-size
+                .content
+                  %span 価格
+                  %i.fa.fa-jpy
+                .content-form
+                  = r.number_field :price, required: true
+              .return-create__content.clearfix
+                .content 説明
+                .content-form
+                  = r.text_area :content, required: true, autofocus: true,
+                    placeholder: "説明文を入力してください。"
+              .return-create__stock.box-size
+                .content 在庫数
+                .content-form
+                  = r.number_field :stock, required: true,
+                    placeholder: "在庫数に制限がない場合は０としてください"
+              .return-create__arrival.box-size
+                .content 発送予定日
+                .content-form
+                  = r.date_select :arrival_date, dafault: Time.current,
+                    use_month_numbers: true, discard_day: true
+              .return-create__image-show.clearfix
+                .content 画像
+                .content-form
+                  = r.file_field :returnimage, id: "create-return-image",
+                    required: true
+                  #return-image-show
+                    %img{ src:"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTvOUSpHlYa1jpsFW2BZB9_T5X68Q-YwCA4GtihyEUOW7AiAqru" ,alt: "画像がありません" ,id: "return-image-default" }
+          - 3.times do |i|
+            .return-fields
+              .return-create
+                %h2 リターンの新規登録
+                .btn.btn-danger.return-delete-button.remove-new-return 不要ならクリック
+                = f.fields_for :returns do |r|
+                  .return-create__title.box-size
+                    .content タイトル
+                    .content-form
+                      = r.text_field :title, required: true, autofocus: true,
+                        placeholder: "タイトルを入力してください。"
+                  .return-create__price.box-size
+                    .content
+                      %span 価格
+                      %i.fa.fa-jpy
+                    .content-form
+                      = r.number_field :price, required: true
+                  .return-create__content.clearfix
+                    .content 説明
+                    .content-form
+                      = r.text_area :content, required: true, autofocus: true,
+                        placeholder: "説明文を入力してください。"
+                  .return-create__stock.box-size
+                    .content 在庫数
+                    .content-form
+                      = r.number_field :stock, required: true,
+                        placeholder: "在庫数に制限がない場合は０としてください"
+                  .return-create__arrival.box-size
+                    .content 発送予定日
+                    .content-form
+                      = r.date_select :arrival_date, dafault: Time.current,
+                        use_month_numbers: true, discard_day: true
+                  .return-create__image-show.clearfix
+                    .content 画像
+                    .content-form
+                      = r.file_field :returnimage, id: "create-return-image",
+                        required: true
+                      #return-image-show
+                        %img{ src:"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTvOUSpHlYa1jpsFW2BZB9_T5X68Q-YwCA4GtihyEUOW7AiAqru" ,alt: "画像がありません" ,id: "return-image-default" }
+
   .blank-content


### PR DESCRIPTION
## What
リターンの複数登録

## Why
リターンを1個しか登録できないのは不便なので

【コメント】
間に合わなかったので途中経過になってしまいますが、こちらの方がよければという提案レベルです。
プロジェクトの新規登録時にリターンを複数登録できるようにしています。
デフォルトで4つ表示していて、減らせるようにしています。

課題としては2点です。
①消したら追加できない(ほんとは1個表示しておいてappendして追加するようにしたかったけど間に合わなかった)
②2個目以降に表示されているリターンの画像を追加した時に画像が反映されるようにしてない