### PR TITLE
リターンのプロジェクトをオーナーでも買えてしまう問題

### DIFF
--- a/app/controllers/returns_controller.rb
+++ b/app/controllers/returns_controller.rb
@@ -5,7 +5,7 @@ class ReturnsController < ApplicationController
 
   # 支払い選択
   def choice
-    redirect_to project_path(params[:id]) if current_user.project_owner?(@project)
+    redirect_to project_path(params[:project_id]) if current_user.project_owner?(@project)
     @returns = @project.returns
     @return = @returns.where(id: params[:select_id])
     @returns_not = @returns.where.not(id: params[:select_id])

--- a/app/controllers/returns_controller.rb
+++ b/app/controllers/returns_controller.rb
@@ -5,6 +5,7 @@ class ReturnsController < ApplicationController
 
   # 支払い選択
   def choice
+    redirect_to project_path(params[:id]) if current_user.project_owner?(@project)
     @returns = @project.returns
     @return = @returns.where(id: params[:select_id])
     @returns_not = @returns.where.not(id: params[:select_id])

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -72,11 +72,12 @@
               .Gauge__obj.is-1{ style: "width: #{ @project.achievement_rate }%;" }
               .Gauge__txt
                 #{ @project.achievement_rate } %
-        = link_to payment_path(params[:id], 'payment/choice',
-               "#{@returns.first.id}", ''), class: 'btn-link',
-                data: {turbolinks: false} do
-          .btn-link__button.btn.btn-danger
-            %p このプロジェクトを支援する
+        - unless current_user&.project_owner?(@project)
+          = link_to payment_path(params[:id], 'payment/choice',
+                 "#{@returns.first.id}", ''), class: 'btn-link',
+                  data: {turbolinks: false} do
+            .btn-link__button.btn.btn-danger
+              %p このプロジェクトを支援する
     .top-content__info-footer
       - if current_user&.project_owner?(@project)
         = link_to edit_project_path(id: params[:id]) do

--- a/app/views/shared/_return-list.html.haml
+++ b/app/views/shared/_return-list.html.haml
@@ -25,6 +25,7 @@
         %i.fa.fa-gift.fa-stack-1x
       %span #{ r.arrival_date.year }年#{ r.arrival_date.month }月に発送予定です。
     .project-return__purchase
-      = link_to payment_path(params[:id], 'payment/choice',
-      r.id, "?select_id=#{ r.id }"), data: {turbolinks: false} do
-        %button.project-select-button  このリターンを購入する
+      - unless current_user&.project_owner?(@project)
+        = link_to payment_path(params[:id], 'payment/choice',
+        r.id, "?select_id=#{ r.id }"), data: {turbolinks: false} do
+          %button.project-select-button  このリターンを購入する

--- a/app/views/shared/_return-list.html.haml
+++ b/app/views/shared/_return-list.html.haml
@@ -27,5 +27,5 @@
     .project-return__purchase
       - unless current_user&.project_owner?(@project)
         = link_to payment_path(params[:id], 'payment/choice',
-        r.id, "?select_id=#{ r.id }"), data: {turbolinks: false} do
+          r.id, "?select_id=#{ r.id }"), data: {turbolinks: false} do
           %button.project-select-button  このリターンを購入する


### PR DESCRIPTION
## What
プロジェクトオーナーはプロジェクトのリターンを変えないようにする

## Why
オーナーがリターン買って自己投資するのはおかしな状況なので

【確認事項】
①project/:idの上段の「このプロジェクトを支援する」ボタンと、「このリターンを購入する」ボタンを
プロジェクトオーナーであれば表示しないように制限
②リクエストを直接行なった場合も、projects/:idページにリダイレクトするように保険をかけておく