### PR TITLE
閲覧履歴が１つしか保存されていなかった問題の修正

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -16,10 +16,7 @@ class ProjectsController < ApplicationController
   end
 
   def show
-    view_history = cookie_find_or_create("project_view_history")
-    view_history.delete_if { |id| id = @project.id }
-    view_history << @project.id
-    cookie_save("project_view_history", view_history)
+    save_project_id_to_cookie(@project)
     @like = @project.likes.find_by(user_id: current_user.id) if user_signed_in?
     @returns = @project.returns.order('price ASC' )
     @category = @project.category
@@ -129,5 +126,12 @@ class ProjectsController < ApplicationController
       tag_ids: [],
       returns_attributes: [:title, :price, :content, :stock, :arrival_date, :returnimage, :_destroy, :id]
     ).merge(testdata)
+  end
+
+  def save_project_id_to_cookie(project)
+    view_history = cookie_find_or_create("project_view_history")
+    view_history.delete_if { |id| id == project.id }
+    view_history << project.id
+    cookie_save("project_view_history", view_history)
   end
 end


### PR DESCRIPTION
## WHAT
閲覧履歴をCookieに保存していたが、１つしか保存されていなかったので複数保存するように修正。
併せて、メソッドへの切り出しを行った。

## 確認方法
1. 適当はproject/showページを開く。
2. developer toolを開き、↓の画面でCookieのvalueをコピー。
[![Image from Gyazo](https://i.gyazo.com/9fa6d4da67ac4567a9724f474c27b865.png)](https://gyazo.com/9fa6d4da67ac4567a9724f474c27b865)
3. http://urlencode.net/result.cgi で保存されているプロジェクトのIDを確認。
4. 別のproject/showページを開く。
5. もう一度Cookie文字列をコピーして↑のサイトで見て、開いたプロジェクトのIDが追加されていることを確認する。

