### PR TITLE
project/indexのサイドバー 『プロジェクトをさがす』欄の実装

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -21,7 +21,7 @@ class ProjectsController < ApplicationController
 
     if @projects.present?
       @projects_count = @projects.count
-      @projects = @projects.page(params[:page]).per(16)
+      @projects = Kaminari.paginate_array(@projects).page(params[:page]).per(16)
     else
       @projects_count = 0
     end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -7,11 +7,13 @@ class ProjectsController < ApplicationController
 
   def index
     @projects = Project.active
-    return false if project_search_params[:keyword].blank?
 
-    keywords = project_search_params[:keyword].gsub(/(\S+)/, '%\0%').split(/\s/)
-    keywords.each do |word|
-      @projects = @projects.search(word)
+    if project_search_params[:keyword]
+      keywords = project_search_params[:keyword].gsub(/(\S+)/, '%\0%').split(/\s/)
+      keywords.each do |word|
+        @projects = @projects.search(word)
+      end
+    end
     end
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -135,4 +135,29 @@ class ProjectsController < ApplicationController
       returns_attributes: [:title, :price, :content, :stock, :arrival_date, :returnimage, :_destroy, :id]
     ).merge(testdata)
   end
+
+  def sort_projects(projects, sort_query)
+    return false if sort_query.blank?
+
+    case sort_query
+    when 'notable'
+      projects.order('likes_count DESC')
+    when 'total_support'
+      projects.order('total_support DESC')
+    when 'one_more_push'
+      projects.one_more_push
+    when 'new'
+      projects.order('created_at DESC')
+    when 'sccessful'
+      projects.select{ |p| p.success? }
+    when 'viewed'
+      view_history = cookie_find_or_create('project_view_history')
+      projects.select{ |p| view_history.include?(p.id) }
+    when 'end_soon'
+      projects.select{ |p| p.success? && p.remaining_time[:day] < 10}
+    when 'community'
+      projects
+    end
+
+  end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -14,6 +14,9 @@ class ProjectsController < ApplicationController
         @projects = @projects.search(word)
       end
     end
+
+    if params[:sort]
+      @projects = sort_projects(@projects, params[:sort])
     end
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -26,7 +26,7 @@ class Project < ApplicationRecord
     select{ |project|
      project.achievement_rate >= 40 && project.remaining_time[:day] <= 30
     }
-    .sort_by{ |project| project.remaining_time }
+    .sort_by{ |project| project.remaining_time.inject(:+) }
   }
 
   # 募集中かどうかを判定

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -22,6 +22,12 @@ class Project < ApplicationRecord
   scope :search,     -> keyword {
     title(keyword).or(content(keyword)).joins(:user).or(owner_name(keyword))
   }
+  scope :one_more_push, -> {
+    select{ |project|
+     project.achievement_rate >= 40 && project.remaining_time[:day] <= 30
+    }
+    .sort_by{ |project| project.remaining_time }
+  }
 
   # 募集中かどうかを判定
   def active?

--- a/app/views/projects/_sidebar.html.haml
+++ b/app/views/projects/_sidebar.html.haml
@@ -26,9 +26,9 @@
     %li.nav-menu-item
       = link_to "もうすぐ終了のプロジェクト", projects_path(sort: 'end_soon')
       %i.fa.fa-angle-right
-    %li.nav-menu-item
-      = link_to "コミュニティ型プロジェクト", projects_path(sort: 'community')
-      %i.fa.fa-angle-right
+    -# %li.nav-menu-item
+      -# = link_to "コミュニティ型プロジェクト", projects_path(sort: 'community')
+      -# %i.fa.fa-angle-right
 .nav-category
   = render 'projects/sidebar/category'
 .nav-area

--- a/app/views/projects/_sidebar.html.haml
+++ b/app/views/projects/_sidebar.html.haml
@@ -6,28 +6,28 @@
     %span#search-project プロジェクトをさがす
   %ul.nav-menu-lists
     %li.nav-menu-item
-      = link_to  "注目のプロジェクト", href: "#"
+      = link_to  "注目のプロジェクト", projects_path(sort: 'notable')
       %i.fa.fa-angle-right
     %li.nav-menu-item
-      = link_to "支援金額の多いプロジェクト", href: "#"
+      = link_to "支援金額の多いプロジェクト", projects_path(sort: 'total_support')
       %i.fa.fa-angle-right
     %li.nav-menu-item
-      = link_to "あとひと押しのプロジェクト", href: "#"
+      = link_to "あとひと押しのプロジェクト", projects_path(sort: 'one_more_push')
       %i.fa.fa-angle-right
     %li.nav-menu-item
-      = link_to "新着プロジェクト", href: "#"
+      = link_to "新着プロジェクト", projects_path(sort: 'new')
       %i.fa.fa-angle-right
     %li.nav-menu-item
-      = link_to "成立済みのプロジェクト", href: "#"
+      = link_to "成立済みのプロジェクト", projects_path(sort: 'sccessful')
       %i.fa.fa-angle-right
     %li.nav-menu-item
-      = link_to "最近見たプロジェクト", href: "#"
+      = link_to "最近見たプロジェクト", projects_path(sort: 'viewed')
       %i.fa.fa-angle-right
     %li.nav-menu-item
-      = link_to "もうすぐ終了のプロジェクト", href: "#"
+      = link_to "もうすぐ終了のプロジェクト", projects_path(sort: 'end_soon')
       %i.fa.fa-angle-right
     %li.nav-menu-item
-      = link_to "コミュニティ型プロジェクト", href: "#"
+      = link_to "コミュニティ型プロジェクト", projects_path(sort: 'community')
       %i.fa.fa-angle-right
 .nav-category
   = render 'projects/sidebar/category'

--- a/app/views/projects/_sidebar.html.haml
+++ b/app/views/projects/_sidebar.html.haml
@@ -5,25 +5,25 @@
       %i.fa.fa-search.fa-stack-1x.fa-inverse
     %span#search-project プロジェクトをさがす
   %ul.nav-menu-lists
-    %li.nav-menu-item
+    %li.nav-menu-item.show-links
       = link_to  "注目のプロジェクト", projects_path(sort: 'notable')
       %i.fa.fa-angle-right
-    %li.nav-menu-item
+    %li.nav-menu-item.show-links
       = link_to "支援金額の多いプロジェクト", projects_path(sort: 'total_support')
       %i.fa.fa-angle-right
-    %li.nav-menu-item
+    %li.nav-menu-item.show-links
       = link_to "あとひと押しのプロジェクト", projects_path(sort: 'one_more_push')
       %i.fa.fa-angle-right
-    %li.nav-menu-item
+    %li.nav-menu-item.show-links
       = link_to "新着プロジェクト", projects_path(sort: 'new')
       %i.fa.fa-angle-right
-    %li.nav-menu-item
+    %li.nav-menu-item.show-links
       = link_to "成立済みのプロジェクト", projects_path(sort: 'sccessful')
       %i.fa.fa-angle-right
-    %li.nav-menu-item
+    %li.nav-menu-item.show-links
       = link_to "最近見たプロジェクト", projects_path(sort: 'viewed')
       %i.fa.fa-angle-right
-    %li.nav-menu-item
+    %li.nav-menu-item.show-links
       = link_to "もうすぐ終了のプロジェクト", projects_path(sort: 'end_soon')
       %i.fa.fa-angle-right
     -# %li.nav-menu-item


### PR DESCRIPTION
## WHAT
+ project/indexのサイドバー各リンクの実装

### 各リンクのソート基準

#### 注目のプロジェクト
+ お気に入り(likes_count)の多い順

#### 支援金額の多いプロジェクト
+ 支援金額(total_support)の多い順

#### あとひと押しのプロジェクト
+ 残り期間が30日未満
+ 達成率40%以上

#### 新着のプロジェクト
+ 作成日(created_at)の若い順

#### 成立済みのプロジェクト
+ 成立している(total_support >= goal)プロジェクト

#### 最近見たプロジェクト
+ 閲覧したことのあるプロジェクト(cookieを参照)
+ 現在は１つしか表示されない
+ #207 で複数保存されるように修正済み

#### もうすぐ終了のプロジェクト
+ 募集期間が10日未満
+ 成立しているプロジェクト

#### コミュニティ型のプロジェクト
+ コミュニティ型のプロジェクトが未実装のため、コメントアウト

## 確認方法
+ 各リンクがhoverでオレンジになるか
+ 各リンクは適切に機能しているか 
+ [コミュニティ型のプロジェクト]は削除されているか