### PR TITLE
購入画面の次に進むボタンが押せないことがある問題を修正

### DIFF
--- a/app/assets/stylesheets/returns/show-progress-button-content.scss
+++ b/app/assets/stylesheets/returns/show-progress-button-content.scss
@@ -40,14 +40,21 @@
     &__next{
       float: right;
       position: relative;
-      input{
+      button{
         height: 55px;
         width: 257px;
         background-color: #B22B30;
         text-align: left;
+      }
+      p{
         font-size: 16px;
+        line-height: 55px;
         color: white;
-        padding-left: 20px;
+        float: left;
+        margin-left: 20px;
+        position: absolute;
+        top: 0;
+        left: 0;
       }
       img{
         float: right;

--- a/app/assets/stylesheets/returns/show-progress-button-content.scss
+++ b/app/assets/stylesheets/returns/show-progress-button-content.scss
@@ -45,16 +45,9 @@
         width: 257px;
         background-color: #B22B30;
         text-align: left;
-      }
-      p{
         font-size: 16px;
-        line-height: 55px;
         color: white;
-        float: left;
-        margin-left: 20px;
-        position: absolute;
-        top: 0;
-        left: 0;
+        padding-left: 20px;
       }
       img{
         float: right;

--- a/app/views/returns/_bank-show.html.haml
+++ b/app/views/returns/_bank-show.html.haml
@@ -69,6 +69,5 @@
           = image_tag 'left_arrow.png'
           %p プロジェクトページに戻る
       .progress-button__next
-        = f.submit ""
-        %p 次に進む
+        = f.submit :次に進む
         = image_tag 'right_arrow.png'

--- a/app/views/returns/_bank-show.html.haml
+++ b/app/views/returns/_bank-show.html.haml
@@ -69,5 +69,6 @@
           = image_tag 'left_arrow.png'
           %p プロジェクトページに戻る
       .progress-button__next
-        = f.submit :次に進む
-        = image_tag 'right_arrow.png'
+        = button_tag type: 'submit' do
+          %p 次に進む
+          = image_tag 'right_arrow.png'

--- a/app/views/returns/_bank.html.haml
+++ b/app/views/returns/_bank.html.haml
@@ -50,5 +50,6 @@
           = image_tag 'left_arrow.png'
           %p プロジェクトページに戻る
       .progress-button__next
-        = submit_tag :次に進む
-        = image_tag 'right_arrow.png'
+        = button_tag type: 'submit' do
+          %p 次に進む
+          = image_tag 'right_arrow.png'

--- a/app/views/returns/_bank.html.haml
+++ b/app/views/returns/_bank.html.haml
@@ -50,6 +50,5 @@
           = image_tag 'left_arrow.png'
           %p プロジェクトページに戻る
       .progress-button__next
-        = submit_tag("")
-        %p 次に進む
+        = submit_tag :次に進む
         = image_tag 'right_arrow.png'

--- a/app/views/returns/_credit-card-show.html.haml
+++ b/app/views/returns/_credit-card-show.html.haml
@@ -56,6 +56,5 @@
           = image_tag 'left_arrow.png'
           %p プロジェクトページに戻る
       .progress-button__next
-        = f.submit ""
-        %p 次に進む
+        = f.submit :次に進む
         = image_tag 'right_arrow.png'

--- a/app/views/returns/_credit-card-show.html.haml
+++ b/app/views/returns/_credit-card-show.html.haml
@@ -56,5 +56,6 @@
           = image_tag 'left_arrow.png'
           %p プロジェクトページに戻る
       .progress-button__next
-        = f.submit :次に進む
-        = image_tag 'right_arrow.png'
+        = button_tag type: 'submit' do
+          %p 次に進む
+          = image_tag 'right_arrow.png'

--- a/app/views/returns/_credit-card.html.haml
+++ b/app/views/returns/_credit-card.html.haml
@@ -53,6 +53,5 @@
           = image_tag 'left_arrow.png'
           %p プロジェクトページに戻る
       .progress-button__next
-        = submit_tag("")
-        %p 次に進む
+        = submit_tag :次に進む
         = image_tag 'right_arrow.png'

--- a/app/views/returns/_credit-card.html.haml
+++ b/app/views/returns/_credit-card.html.haml
@@ -53,5 +53,6 @@
           = image_tag 'left_arrow.png'
           %p プロジェクトページに戻る
       .progress-button__next
-        = submit_tag :次に進む
-        = image_tag 'right_arrow.png'
+        = button_tag type: 'submit' do
+          %p 次に進む
+          = image_tag 'right_arrow.png'

--- a/app/views/returns/choice.html.haml
+++ b/app/views/returns/choice.html.haml
@@ -75,8 +75,7 @@
               = image_tag 'left_arrow.png'
               %p プロジェクトページに戻る
           .progress-button__next
-            = submit_tag("")
-            %p 次に進む
+            = submit_tag :次に進む
             = image_tag 'right_arrow.png'
 
     .bottom-content

--- a/app/views/returns/choice.html.haml
+++ b/app/views/returns/choice.html.haml
@@ -75,8 +75,9 @@
               = image_tag 'left_arrow.png'
               %p プロジェクトページに戻る
           .progress-button__next
-            = submit_tag :次に進む
-            = image_tag 'right_arrow.png'
+            = button_tag type: 'submit' do
+              %p 次に進む
+              = image_tag 'right_arrow.png'
 
     .bottom-content
       .contact-us-content


### PR DESCRIPTION
## What
購入画面の次に進むボタンのテキスト上をクリックすると押されたことにならない問題を修正しました。

確認方法
・各画面の次に進むボタンをクリックして次の画面に進めること。
<img width="545" alt="2018-08-01 15 38 48" src="https://user-images.githubusercontent.com/39818234/43505175-0ae77c98-95a1-11e8-872d-45b0bda47770.png">