### PR TITLE
リターンのstock数に応じた購入ボタンの切り替え

### DIFF
--- a/app/assets/stylesheets/projects/show-return-content.scss
+++ b/app/assets/stylesheets/projects/show-return-content.scss
@@ -97,18 +97,21 @@
     }
     &__purchase {
       margin-top: 20px;
-      .project-select-button {
-        box-shadow: 0 2px rgba(0,0,0,0.2);
-      }
       button {
         width: 300px;
         height: 60px;
         display: block;
-        background-color: red;
-        color: white;
         border-radius: 10px;
         font-size: 22px;
 
+      }
+      .project-select-button {
+        box-shadow: 0 2px rgba(0,0,0,0.2);
+        background-color: red;
+        color: white;
+      }
+      .invalid-payment-btn {
+        color: black;
       }
     }
   }

--- a/app/assets/stylesheets/returns/show-return-list-content.scss
+++ b/app/assets/stylesheets/returns/show-return-list-content.scss
@@ -55,6 +55,9 @@
         span{
           font-size: 20px;
         }
+        .number-none {
+          text-align: center;
+        }
       }
     }
     .return-item-right{

--- a/app/models/return.rb
+++ b/app/models/return.rb
@@ -16,4 +16,8 @@ class Return < ApplicationRecord
       end
     end
   end
+
+  def return_active?
+    self.stock >= 1
+  end
 end

--- a/app/views/returns/_return-item.html.haml
+++ b/app/views/returns/_return-item.html.haml
@@ -19,15 +19,21 @@
 
         - if returns.count == 1
           .return-numbar.col
-            = select_tag "number[#{ item.id }]",
-            options_for_select(return_count_options(), selected: 1),
-             class: 'number-select'
-            %span 個
+            - if item.return_active?
+              = select_tag "number[#{ item.id }]",
+              options_for_select(return_count_options(), selected: 1),
+               class: 'number-select'
+              %span 個
+            - else
+              .number-none 販売終了しました
         - else
           .return-numbar.col
-            = select_tag "number[#{ item.id }]",
-            options_for_select(return_count_options()), class: 'number-select'
-            %span 個
+            - if item.return_active?
+              = select_tag "number[#{ item.id }]",
+              options_for_select(return_count_options()), class: 'number-select'
+              %span 個
+            - else
+              .number-none 販売終了しました
 
       .return-item-right.col-sm-8
         .return-item-right__text.col

--- a/app/views/shared/_return-list.html.haml
+++ b/app/views/shared/_return-list.html.haml
@@ -15,7 +15,7 @@
         %i.fa.fa-circle-o.fa-stack-2x
         %i.fa.fa-user.fa-stack-1x
       %span #{r.user_returns.count_return_users}人が支援中/
-      - if r.stock <= 0
+      - unless r.return_active?
         %span 在庫なし
       - else
         %span 残り#{ number_with_delimiter(r.stock) }個
@@ -26,7 +26,7 @@
       %span #{ r.arrival_date.year }年#{ r.arrival_date.month }月に発送予定です。
     .project-return__purchase
       - unless current_user&.project_owner?(@project)
-        - if r.stock > 0
+        - if r.return_active?
           = link_to payment_path(params[:id], 'payment/choice',
             r.id, "?select_id=#{ r.id }"), data: {turbolinks: false} do
             %button.project-select-button  このリターンを購入する

--- a/app/views/shared/_return-list.html.haml
+++ b/app/views/shared/_return-list.html.haml
@@ -15,8 +15,8 @@
         %i.fa.fa-circle-o.fa-stack-2x
         %i.fa.fa-user.fa-stack-1x
       %span #{r.user_returns.count_return_users}人が支援中/
-      - if r.stock === 0
-        %span 在庫制限なし
+      - if r.stock <= 0
+        %span 在庫なし
       - else
         %span 残り#{ number_with_delimiter(r.stock) }個
     .project-return__arrival
@@ -26,6 +26,9 @@
       %span #{ r.arrival_date.year }年#{ r.arrival_date.month }月に発送予定です。
     .project-return__purchase
       - unless current_user&.project_owner?(@project)
-        = link_to payment_path(params[:id], 'payment/choice',
-          r.id, "?select_id=#{ r.id }"), data: {turbolinks: false} do
-          %button.project-select-button  このリターンを購入する
+        - if r.stock > 0
+          = link_to payment_path(params[:id], 'payment/choice',
+            r.id, "?select_id=#{ r.id }"), data: {turbolinks: false} do
+            %button.project-select-button  このリターンを購入する
+        - else
+          %button.invalid-payment-button 販売終了しました

--- a/app/views/shared/_return-list.html.haml
+++ b/app/views/shared/_return-list.html.haml
@@ -15,10 +15,10 @@
         %i.fa.fa-circle-o.fa-stack-2x
         %i.fa.fa-user.fa-stack-1x
       %span #{r.user_returns.count_return_users}人が支援中/
-      - unless r.return_active?
-        %span 在庫なし
-      - else
+      - if r.return_active?
         %span 残り#{ number_with_delimiter(r.stock) }個
+      - else
+        %span 在庫なし
     .project-return__arrival
       %span.fa-stack.fa-lg
         %i.fa.fa-circle-o.fa-stack-2x


### PR DESCRIPTION
## What
リターンのストックが0の場合のボタンの表示の切り替え

## Why
リターンの数に応じた制限をするため

【確認方法】
リターンを0になるように買ってもらい、購入ボタンとストックの残数表記が変わるか確認