### PR TITLE
支払い処理へのデバッグメソッドの仕込み

### DIFF
--- a/app/controllers/user_returns_controller.rb
+++ b/app/controllers/user_returns_controller.rb
@@ -8,7 +8,9 @@ class UserReturnsController < ApplicationController
     if params[:user_return][:mode] == 'card'
       # 決済処理
       if params['payjpToken'].present?
-        if Payjp::Charge.create(currency: 'jpy', amount: return_sum, card: params['payjpToken'])
+        payment = Payjp::Charge.create(currency: 'jpy', amount: return_sum, card: params['payjpToken'])
+        if payment
+          logger.debug(payment)
           # 初めてリターン購入した人ならばtotal_userに1足す
           Return.total_user_sum(user_return_params[:number], current_user.id)
           # リターン購入分のレコード保存


### PR DESCRIPTION
## WHAT
支払い処理時、pay.jpからのデータをログに出力するようにした。

## WHY
原因不明のエラーが支払い処理に起因するものか調査するため。